### PR TITLE
Make Icons Bindable

### DIFF
--- a/tests/AP.MobileToolkit.Fonts.Tests/BindableIconNameTests.cs
+++ b/tests/AP.MobileToolkit.Fonts.Tests/BindableIconNameTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AP.MobileToolkit.Fonts.Tests.Mocks;
+using Xamarin.Forms;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AP.MobileToolkit.Fonts.Tests
+{
+    public class BindableIconNameTests : TestBase
+    {
+        public BindableIconNameTests(ITestOutputHelper testOutputHelper, FontRegistrySetup setup)
+            : base(testOutputHelper, setup)
+        {
+        }
+
+        [Fact]
+        public void NoBindingContext_HasNoElements()
+        {
+            var page = new Page1();
+            Assert.Empty(page.MainLayout.Children);
+        }
+
+        [Fact]
+        public void WhenBindingContextIsSet_HasTwoChildren()
+        {
+            var page = new Page1
+            {
+                BindingContext = new Page1ViewModel()
+            };
+
+            Assert.Equal(2, page.MainLayout.Children.Count);
+        }
+
+        [Theory]
+        [InlineData(0, "\uf024")]
+        [InlineData(1, "\uf025")]
+        public void TextPropertyIsSet(int index, string glyph)
+        {
+            var page = new Page1
+            {
+                BindingContext = new Page1ViewModel()
+            };
+
+            var label = page.MainLayout.Children.ElementAt(index) as Label;
+            Assert.NotNull(label);
+            Assert.Equal(glyph, label.Text);
+            Assert.Equal(MockFont.Font.FontFileName, label.FontFamily);
+        }
+    }
+}

--- a/tests/AP.MobileToolkit.Fonts.Tests/FontRegistrySetup.cs
+++ b/tests/AP.MobileToolkit.Fonts.Tests/FontRegistrySetup.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AP.MobileToolkit.Fonts.Tests.Mocks;
-using Xunit.Abstractions;
 
 namespace AP.MobileToolkit.Fonts.Tests
 {

--- a/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1.xaml
+++ b/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ap="http://avantipoint.com/mobiletoolkit"
+             mc:Ignorable="d"
+             x:Class="AP.MobileToolkit.Fonts.Tests.Mocks.Page1">
+  <StackLayout BindableLayout.ItemsSource="{Binding Icons}" x:Name="mainLayout">
+    <BindableLayout.ItemTemplate>
+      <DataTemplate>
+        <Label Text="{ap:Icon IconName={Binding .}}" />
+      </DataTemplate>
+    </BindableLayout.ItemTemplate>
+  </StackLayout>
+</ContentPage>

--- a/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1.xaml.cs
+++ b/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace AP.MobileToolkit.Fonts.Tests.Mocks
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Page1
+    {
+        public Page1()
+        {
+            InitializeComponent();
+        }
+
+        public StackLayout MainLayout => mainLayout;
+    }
+}

--- a/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1ViewModel.cs
+++ b/tests/AP.MobileToolkit.Fonts.Tests/Mocks/Page1ViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace AP.MobileToolkit.Fonts.Tests.Mocks
+{
+    public class Page1ViewModel
+    {
+        public Page1ViewModel()
+            : this("test foo", "test foo-bar")
+        {
+        }
+
+        public Page1ViewModel(params string[] icons)
+        {
+            Icons = icons;
+        }
+
+        public IEnumerable<string> Icons { get; }
+    }
+}


### PR DESCRIPTION
# Description

Updates Icon extension to support bindings. This can help for a variety of things such as dynamic menus.

- fixes #12 