### PR TITLE
use custom Android Resource name

### DIFF
--- a/src/forms/AP.MobileToolkit.Forms.Fonts/AP.MobileToolkit.Forms.Fonts.csproj
+++ b/src/forms/AP.MobileToolkit.Forms.Fonts/AP.MobileToolkit.Forms.Fonts.csproj
@@ -13,6 +13,10 @@
     <DefineConstants>$(DefineConstants);UWP</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <AndroidResgenClass>FontsResource</AndroidResgenClass>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="**/Platform/**/*.cs" />
     <None Include="**/Platform/**/*.cs" />


### PR DESCRIPTION
# Description

Use Custom Android Resource class name to avoid namespace conflict with AP.MobileToolkit