### PR TITLE
use full namespace for Android Resources

### DIFF
--- a/src/forms/AP.MobileToolkit.Forms.Fonts/AP.MobileToolkit.Forms.Fonts.csproj
+++ b/src/forms/AP.MobileToolkit.Forms.Fonts/AP.MobileToolkit.Forms.Fonts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10;MonoAndroid90;MonoAndroid10.0</TargetFrameworks>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <AndroidResgenClass>FontsResource</AndroidResgenClass>
+    <RootNamespace>AP.MobileToolkit.Forms.Fonts</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/winui/AP.MobileToolkit.WinUI.Fonts/AP.MobileToolkit.WinUI.Fonts.csproj
+++ b/src/winui/AP.MobileToolkit.WinUI.Fonts/AP.MobileToolkit.WinUI.Fonts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20</TargetFrameworks>
@@ -13,6 +13,10 @@
 
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('uap10')) ">
     <DefineConstants>$(DefineConstants);UWP</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <RootNamespace>AP.MobileToolkit.Forms.Fonts</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Overrides the Rootnamespace on Android so that the generated Resources file is put into the Assembly qualified namespace. This will prevent namespace conflicts with the AP.MobileToolkit. The `AndroidResgenClass` was not being respected and the default class name Resources was what was being generated.