### PR TITLE
fix symbols packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
     <Copyright>Copyright © AvantiPoint 2016-2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>avantipoint-icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/AvantiPoint/AP.MobileToolkit</PackageProjectUrl>
+    <PackageProjectUrl>https://avantipoint.github.io/AP.MobileToolkit/fonts/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/AvantiPoint/AP.MobileToolkit</RepositoryUrl>
+    <RepositoryUrl>https://github.com/AvantiPoint/AP.MobileToolkit.Fonts.git</RepositoryUrl>
     <PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
     <PackageOutputPath Condition=" '$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != '' ">$(BUILD_ARTIFACTSTAGINGDIRECTORY)</PackageOutputPath>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
@@ -21,6 +21,14 @@
     <IS_PREVIEW Condition=" '$(IS_PREVIEW)' == '' ">false</IS_PREVIEW>
     <IS_RELEASE Condition=" '$(IS_RELEASE)' == '' ">false</IS_RELEASE>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup> 
+
+  <PropertyGroup>
+    <!-- Nuget source link -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <!-- Font Assets -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,10 +63,15 @@ stages:
 
           - powershell: |
               dotnet restore .\build-maui.slnf --configfile .\build\nuget.config
-              dotnet build build-maui.slnf -c Release
-            displayName: Build Maui Packages
+            displayName: Restore Maui Projects
             env:
               DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+          - task: MSBuild@1
+            displayName: Build Maui Packages
+            inputs:
+              solution: build-maui.slnf
+              configuration: 'Release'
 
           - powershell: |
               dotnet test tests\AP.MobileToolkit.Fonts.Tests\AP.MobileToolkit.Fonts.Tests.csproj --configuration Release --logger trx --no-build --collect "Code Coverage"

--- a/src/maui/AP.MobileToolkit.Maui.Fonts/Controls/FontIcon.cs
+++ b/src/maui/AP.MobileToolkit.Maui.Fonts/Controls/FontIcon.cs
@@ -54,7 +54,7 @@ namespace AP.MobileToolkit.Fonts.Controls
             }
         }
 
-            public static void RegisterDefaultOnChangedHandler(FontIconHandler fontIconHandler) =>
+        public static void RegisterDefaultOnChangedHandler(FontIconHandler fontIconHandler) =>
             _defaultOnChanged = fontIconHandler;
 
         public static IconImageSource CreateIconImageSource(BindableObject bindable, string selector) =>


### PR DESCRIPTION
# Description

Fixes symbols packages being created as symbols.nupkg instead of snupkg which causes conflicts when trying to upload to nuget.org.
Fixes Project links in nuget packages